### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for interacting with Qiita, the knowledge-sharing platform for engineers.
 
+<a href="https://glama.ai/mcp/servers/@2bo/qiita-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@2bo/qiita-mcp-server/badge" alt="Qiita Server MCP server" />
+</a>
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Overview


### PR DESCRIPTION
This PR adds a badge for the [Qiita MCP Server](https://glama.ai/mcp/servers/@2bo/qiita-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@2bo/qiita-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@2bo/qiita-mcp-server/badge" alt="Qiita Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.