### PR TITLE
QiitaTeam をサポートする

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ The server provides the following MCP tools:
 }
 ```
 
+### Environment Variables
+
+- `QIITA_API_TOKEN`: Your Qiita API access token (required)
+- `QIITA_TEAM_SUBDOMAIN`: Your Qiita Team subdomain (optional, for Qiita Team users only)
+
 ## Development
 
 ### Setup

--- a/src/services/qiita.ts
+++ b/src/services/qiita.ts
@@ -3,11 +3,18 @@
  * API通信の共通処理を提供します
  */
 export class QiitaApiService {
-  private readonly baseUrl = 'https://qiita.com/api/v2';
+  private readonly baseUrl: string;
   private apiToken: string | undefined;
+  private teamSubdomain: string | undefined;
 
   constructor() {
     this.apiToken = process.env.QIITA_API_TOKEN;
+    this.teamSubdomain = process.env.QIITA_TEAM_SUBDOMAIN;
+    
+    // QiitaTeamのサブドメインが指定されている場合はそちらを使用
+    this.baseUrl = this.teamSubdomain 
+      ? `https://${this.teamSubdomain}.qiita.com/api/v2`
+      : 'https://qiita.com/api/v2';
   }
 
   /**


### PR DESCRIPTION
## Summary
- Qiita Team のサブドメインのサポートを追加
- 環境変数 `QIITA_TEAM_SUBDOMAIN` を使用してチームサブドメインを指定可能に
- 未設定時は従来通り通常の Qiita API を使用

## Changes
- `QiitaApiService` クラスで API のベース URL を動的に切り替える機能を実装
- README に環境変数の説明を追加
