### PR TITLE
記事検索機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The server provides the following MCP tools:
 |-----------|-------------|
 | `get_my_qiita_articles` | Get current authenticated user's Qiita articles |
 | `get_qiita_item` | Get a specific Qiita article by its ID |
+| `search_qiita_articles` | Search Qiita articles with query string (supports keywords, tags, users) |
 | `post_qiita_article` | Create a new article on Qiita |
 | `update_qiita_article` | Update an existing Qiita article |
 | `get_qiita_markdown_rules` | Get Qiita markdown syntax rules and cheat sheet |

--- a/src/services/qiita.ts
+++ b/src/services/qiita.ts
@@ -213,6 +213,37 @@ export class QiitaApiService {
   };
 
   /**
+   * 記事を検索
+   */
+  searchItems = async (
+    query: string,
+    options: {
+      page?: number;
+      per_page?: number;
+    } = {}
+  ): Promise<any[]> => {
+    const { page = 1, per_page = 20 } = options;
+    
+    const params = new URLSearchParams({
+      query: query,
+      page: page.toString(),
+      per_page: per_page.toString()
+    });
+    
+    const response = await fetch(
+      `${this.baseUrl}/items?${params}`,
+      { headers: this.apiToken ? this.getHeaders() : { 'Content-Type': 'application/json' } }
+    );
+    
+    if (!response.ok) {
+      await this.handleErrorResponse(response);
+    }
+    
+    const items = await response.json();
+    return this.filterItems(items);
+  };
+
+  /**
    * Markdown構文ガイドを取得
    * Qiitaの特定記事のbodyを返す
    */

--- a/src/tools/qiitaTools.ts
+++ b/src/tools/qiitaTools.ts
@@ -116,6 +116,24 @@ const updateQiitaArticle = async (params: UpdateArticleParams): Promise<any> => 
   }
 };
 
+const searchArticlesSchema = z.object({
+  query: z.string().describe("Search query string (e.g., 'qiita user:Qiita', 'TypeScript tag:React')"),
+  page: z.number().optional().default(1).describe("Page number (1-100)"),
+  per_page: z.number().optional().default(20).describe("Number of items per page (1-100)")
+});
+type SearchArticlesParams = z.infer<typeof searchArticlesSchema>;
+
+const searchQiitaArticles = async (params: SearchArticlesParams): Promise<any> => {
+  try {
+    const { query, page = 1, per_page = 20 } = params;
+    const items = await apiService.searchItems(query, { page, per_page });
+    return createSuccessResponse(JSON.stringify(items, null, 2));
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return createErrorResponse(`Error searching Qiita articles: ${errorMessage}`);
+  }
+};
+
 const getQiitaMarkdownRules = async (): Promise<any> => {
   try {
     const markdownRules = await apiService.getMarkdownRules();
@@ -139,6 +157,12 @@ export const getToolDefinitions = () => {
       description: "get a specific Qiita article by its ID",
       parameters: getItemSchema.shape,
       handler: (params: GetItemParams) => getQiitaItem(params)
+    },
+    {
+      name: "search_qiita_articles",
+      description: "search Qiita articles with query string (supports keywords, tags, users)",
+      parameters: searchArticlesSchema.shape,
+      handler: (params: SearchArticlesParams) => searchQiitaArticles(params)
     },
     {
       name: "update_qiita_article",


### PR DESCRIPTION

## Summary

- Qiita記事の検索機能を追加
- `search_qiita_articles`ツールを実装
- キーワード、タグ、ユーザー検索に対応

## Changes

### 新機能
- **QiitaApiService**: `searchItems`メソッドを追加
  - Qiita API v2の`/items`エンドポイントを使用
  - `query`パラメータで検索クエリを指定

- **MCPツール**: `search_qiita_articles`を追加
  - 検索クエリ文字列をサポート
  - 例: `"TypeScript tag:React"`, `"qiita user:Qiita"`

### ドキュメント更新
- README.mdのツール一覧に検索機能を追加

